### PR TITLE
Renamed SlideDirection to SlideTransition

### DIFF
--- a/Sources/DeckUI/DSL/Slide.swift
+++ b/Sources/DeckUI/DSL/Slide.swift
@@ -15,16 +15,16 @@ public struct Slide: Identifiable {
     let padding: CGFloat
     let comment: String?
     let theme: Theme?
-    let direction: SlideTransition?
+    let transition: SlideTransition?
     @ContentItemArrayBuilder var contentItems: () -> [ContentItem]
     
-    public init(alignment: Alignment = .topLeading, padding: CGFloat = 40, comment: String? = nil, theme: Theme? = nil, direction: SlideTransition? = nil, @ContentItemArrayBuilder contentItems: @escaping () -> [ContentItem]) {
+    public init(alignment: Alignment = .topLeading, padding: CGFloat = 40, comment: String? = nil, theme: Theme? = nil, transition: SlideTransition? = nil, @ContentItemArrayBuilder contentItems: @escaping () -> [ContentItem]) {
         self.alignment = alignment
         self.horizontalAlignment = .leading
         self.padding = padding
         self.comment = comment
         self.theme = theme
-        self.direction = direction
+        self.transition = transition
         self.contentItems = contentItems
     }
     

--- a/Sources/DeckUI/DSL/Slide.swift
+++ b/Sources/DeckUI/DSL/Slide.swift
@@ -15,10 +15,10 @@ public struct Slide: Identifiable {
     let padding: CGFloat
     let comment: String?
     let theme: Theme?
-    let direction: SlideDirection?
+    let direction: SlideTransition?
     @ContentItemArrayBuilder var contentItems: () -> [ContentItem]
     
-    public init(alignment: Alignment = .topLeading, padding: CGFloat = 40, comment: String? = nil, theme: Theme? = nil, direction: SlideDirection? = nil, @ContentItemArrayBuilder contentItems: @escaping () -> [ContentItem]) {
+    public init(alignment: Alignment = .topLeading, padding: CGFloat = 40, comment: String? = nil, theme: Theme? = nil, direction: SlideTransition? = nil, @ContentItemArrayBuilder contentItems: @escaping () -> [ContentItem]) {
         self.alignment = alignment
         self.horizontalAlignment = .leading
         self.padding = padding

--- a/Sources/DeckUI/Deprecations.swift
+++ b/Sources/DeckUI/Deprecations.swift
@@ -1,0 +1,21 @@
+//
+//  Deprecations.swift
+//  DeckUI
+//
+//  Created by Josh Holtz on 9/11/22.
+//
+
+import Foundation
+
+public extension Presenter {
+
+    @available(iOS, deprecated: 1, renamed: "init(deck:slideTransition:loop:defaultResolution:showCamera:cameraConfig:)")
+    @available(tvOS, deprecated: 1, renamed: "init(deck:slideTransition:loop:defaultResolution:showCamera:cameraConfig:)")
+    @available(watchOS, deprecated: 1, renamed: "init(deck:slideTransition:loop:defaultResolution:showCamera:cameraConfig:)")
+    @available(macOS, deprecated: 1, renamed: "init(deck:slideTransition:loop:defaultResolution:showCamera:cameraConfig:)")
+    @available(macCatalyst, deprecated: 1, renamed: "init(deck:slideTransition:loop:defaultResolution:showCamera:cameraConfig:)")
+    init(deck: Deck, slideDirection: SlideTransition, loop: Bool = false, defaultResolution: DefaultResolution = (width: 1920, height: 1080), showCamera: Bool = false, cameraConfig: CameraConfig = CameraConfig()) {
+        self = Presenter(deck: deck, slideTransition: slideDirection, loop: loop, defaultResolution: defaultResolution, showCamera: showCamera, cameraConfig: cameraConfig)
+    }
+    
+}

--- a/Sources/DeckUI/Views/Presenter.swift
+++ b/Sources/DeckUI/Views/Presenter.swift
@@ -161,7 +161,7 @@ public struct Presenter: View {
         
         let nextSlide = slides[self.index]
         
-        self.activeTransition = (nextSlide.direction ?? self.slideTransition).next
+        self.activeTransition = (nextSlide.transition ?? self.slideTransition).next
     }
     
     private func previousSlide() {
@@ -177,7 +177,7 @@ public struct Presenter: View {
             self.index -= 1
         }
 
-        self.activeTransition = (currSlide.direction ?? self.slideTransition).previous
+        self.activeTransition = (currSlide.transition ?? self.slideTransition).previous
     }
 }
 

--- a/Sources/DeckUI/Views/Presenter.swift
+++ b/Sources/DeckUI/Views/Presenter.swift
@@ -14,7 +14,7 @@ public struct Presenter: View {
     public typealias DefaultResolution = (width: Double, height: Double)
     
     let deck: Deck
-    let slideDirection: SlideDirection?
+    let slideTransition: SlideTransition?
     let loop: Bool
     let defaultResolution: DefaultResolution
     let showCamera: Bool
@@ -24,9 +24,9 @@ public struct Presenter: View {
     @State var isFullScreen = false
     @State var activeTransition: AnyTransition = .slideFromTrailing
     
-    public init(deck: Deck, slideDirection: SlideDirection? = .horizontal, loop: Bool = false, defaultResolution: DefaultResolution = (width: 1920, height: 1080), showCamera: Bool = false, cameraConfig: CameraConfig = CameraConfig()) {
+    public init(deck: Deck, slideTransition: SlideTransition? = .horizontal, loop: Bool = false, defaultResolution: DefaultResolution = (width: 1920, height: 1080), showCamera: Bool = false, cameraConfig: CameraConfig = CameraConfig()) {
         self.deck = deck
-        self.slideDirection = slideDirection
+        self.slideTransition = slideTransition
         self.loop = loop
         self.defaultResolution = defaultResolution
         self.showCamera = showCamera
@@ -161,7 +161,7 @@ public struct Presenter: View {
         
         let nextSlide = slides[self.index]
         
-        self.activeTransition = (nextSlide.direction ?? self.slideDirection).next
+        self.activeTransition = (nextSlide.direction ?? self.slideTransition).next
     }
     
     private func previousSlide() {
@@ -177,15 +177,15 @@ public struct Presenter: View {
             self.index -= 1
         }
 
-        self.activeTransition = (currSlide.direction ?? self.slideDirection).previous
+        self.activeTransition = (currSlide.direction ?? self.slideTransition).previous
     }
 }
 
-public enum SlideDirection {
+public enum SlideTransition {
     case horizontal, vertical
 }
 
-extension Optional where Wrapped == SlideDirection {
+extension Optional where Wrapped == SlideTransition {
     var next: AnyTransition {
         switch self {
         case .horizontal:


### PR DESCRIPTION
Fixes #5

Deprecates use of `Presenter(deck: deck, slideDirection: .vertical)` and will present and autofix in Xcode to `Presenter(deck: deck, slideTransition: .vertical)`

cc: @yonomitt 