### PR TITLE
Python syntax highlighting

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -8,6 +8,15 @@
         "revision" : "7f4df436eb78fe64fe2c32c58006e9949fa28ad8",
         "version" : "0.16.0"
       }
+    },
+    {
+      "identity" : "splashpython",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/yonomitt/SplashPython.git",
+      "state" : {
+        "revision" : "cc3fec6049ec45a428d94b8437daad5ed784d783",
+        "version" : "1.0.0"
+      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -15,13 +15,14 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/johnsundell/Splash.git", from: "0.16.0"),
+        .package(url: "https://github.com/yonomitt/SplashPython.git", from: "1.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "DeckUI",
-            dependencies: ["Splash"]),
+            dependencies: ["Splash", "SplashPython"]),
         .testTarget(
             name: "DeckUITests",
             dependencies: ["DeckUI"]),

--- a/Sources/DeckUI/Syntax Highlight/ProgrammingLanguage.swift
+++ b/Sources/DeckUI/Syntax Highlight/ProgrammingLanguage.swift
@@ -6,9 +6,11 @@
 //
 
 import Splash
+import SplashPython
 
 public enum ProgrammingLanguage: String {
     case none
+    case python
     case swift
     
     var name: String {
@@ -17,6 +19,8 @@ public enum ProgrammingLanguage: String {
     
     var grammar: Grammar {
         switch self {
+        case .python:
+            return PythonGrammar()
         case .swift:
             return SwiftGrammar()
         case .none:


### PR DESCRIPTION
This PR does a few things:

1. Creates a public `init` for CodeTheme so people can easily create new code themes
2. Adds SplashPython as a dependency
3. Adds support for Python as one of the languages that can be highlighted