### PR TITLE
Added support for Markdown and AttributedString in Words

### DIFF
--- a/Sources/DeckUI/DSL/ContentItems/Words.swift
+++ b/Sources/DeckUI/DSL/ContentItems/Words.swift
@@ -12,17 +12,32 @@ public struct Words: ContentItem {
     let text: String
     let color: Color?
     let font: Font?
+    let attributedText: AttributedString?
     
-    public init(_ text: String, color: Color? = nil, font: Font? = nil) {
-        self.text = text
+    public init(_ text: String, color: Color? = nil, font: Font? = nil, markdown: Bool = false) {
+        if let markdown = try? AttributedString(markdown: text) {
+            self.attributedText = markdown
+            self.text = String(markdown.characters)
+        } else {
+            self.text = text
+            self.attributedText = nil
+        }
         self.color = color
         self.font = font
     }
     
+    public init(_ attributedText: AttributedString, color: Color? = nil, font: Font? = nil) {
+        self.text = String(attributedText.characters)
+        self.color = color
+        self.font = font
+        self.attributedText = attributedText
+    }
+    
+    
     // TODO: Use theme
     public func buildView(theme: Theme) -> AnyView {
         AnyView(
-            Text(self.text)
+            ((attributedText != nil) ? Text(self.attributedText!) : Text(self.text))
                 .font(self.font ?? theme.body.font)
                 .foregroundColor(self.color ?? theme.body.color)
         )


### PR DESCRIPTION
This addresses #29 with support for Markdown in two ways:
1. Passing in a String to Words and setting markdown = true (internally it will attempt to create an AttributedString
2. Passing in an AttributedString directly to Words