### PR TITLE
Adds a presenter notes view for macOS

### DIFF
--- a/DeckUI.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DeckUI.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "splash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/johnsundell/Splash.git",
+      "state" : {
+        "revision" : "7f4df436eb78fe64fe2c32c58006e9949fa28ad8",
+        "version" : "0.16.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Examples/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Examples/Demo/Demo.xcodeproj/project.pbxproj
@@ -591,7 +591,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.joshholtz.Demo;
 				PRODUCT_NAME = Demo;
@@ -620,7 +620,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.joshholtz.Demo;
 				PRODUCT_NAME = Demo;

--- a/Examples/Demo/Shared/ContentView.swift
+++ b/Examples/Demo/Shared/ContentView.swift
@@ -17,7 +17,7 @@ struct ContentView: View {
 extension ContentView {
     var deck: Deck {
         Deck(title: "DeckUI Demo") {
-            Slide(alignment: .center) {
+            Slide(alignment: .center, comment: "Here are some presenter notes") {
                 Title("Introducing...")
             }
             
@@ -40,7 +40,7 @@ extension ContentView {
                 }
             }
             
-            Slide(alignment: .center) {
+            Slide(alignment: .center, comment: "The presenter notes are back!") {
                 Title("But why?")
             }
             

--- a/Examples/Demo/Shared/DemoApp.swift
+++ b/Examples/Demo/Shared/DemoApp.swift
@@ -6,12 +6,15 @@
 //
 
 import SwiftUI
-
+import DeckUI
 @main
 struct DemoApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
         }
+        #if canImport(AppKit)
+        PresenterNotes()
+        #endif
     }
 }

--- a/Sources/DeckUI/PresentationState.swift
+++ b/Sources/DeckUI/PresentationState.swift
@@ -1,0 +1,104 @@
+//
+//  PresentationState.swift
+//  
+//
+//  Created by Zachary Brass on 3/12/23.
+//
+
+import SwiftUI
+
+open class PresentationState: ObservableObject {
+    static let shared = PresentationState()
+    @Published var slideIndex = 0
+    
+    var loop = false
+    var slideTransition: SlideTransition? = .horizontal
+    
+    @Published var activeTransition: AnyTransition = .slideFromTrailing
+    
+    // Putting in sample Deck in case the user doesn't assign one. It instructs the user on how to add a Deck of their own
+    open var deck: Deck = Deck(title: "DeckUI Example") {
+            Slide(alignment: .center, comment: "Presenter notes are passed into the comment argument in the init method each of Slide") {
+                Title("DeckUI Example")
+            }
+            
+            Slide(alignment: .center) {
+                Title("Getting Started")
+                Columns {
+                    Column {
+                        Code(.swift) {
+                        """
+                        import SwiftUI
+                        import DeckUI
+                        
+                        struct ContentView: View {
+                            var body: some View {
+                                Presenter(deck: self.deck)
+                            }
+                        }
+
+                        extension ContentView {
+                            var deck: Deck {
+                                Deck(title: "SomeConf 2023") {
+                                    Slide(alignment: .center) {
+                                        Title("Welcome to DeckUI")
+                                    }
+                        
+                                    Slide {
+                                        Title("Slide 1")
+                                        Words("Some useful content")
+                                    }
+                                }
+                            }
+                        }
+                        """
+                        }
+                    }
+                    
+                    Column {
+                        Bullets(style: .bullet) {
+                            Words("Create a `Deck` with multiple `Slide` ")
+                            Words("Create `Presenter` and give a deck")
+                            Words("`Presenter` is a SwiftUI View to present a `Deck`")
+                        }
+                    }
+                }
+            }
+        }
+    public func nextSlide() {
+        let slides = self.deck.slides()
+        if slideIndex >= (slides.count - 1) {
+            if self.loop {
+                slideIndex = 0
+            }
+        } else {
+            slideIndex += 1
+        }
+        
+        let nextSlide = slides[slideIndex]
+        
+        self.activeTransition = (nextSlide.transition ?? self.slideTransition).next
+        NotificationCenter.default.post(name: .slideChanged, object: nextSlide)
+
+    }
+    
+    public func previousSlide() {
+        let slides = self.deck.slides()
+
+        let currentSlide = slides[slideIndex]
+        
+        if slideIndex <= 0 {
+            if self.loop {
+                slideIndex = slides.count - 1
+            }
+        } else {
+            slideIndex -= 1
+        }
+
+        let previousSlide = slides[slideIndex]
+        
+        self.activeTransition = (currentSlide.transition ?? self.slideTransition).previous
+        NotificationCenter.default.post(name: .slideChanged, object: previousSlide)
+
+    }
+}

--- a/Sources/DeckUI/Views/PresenterNotesView.swift
+++ b/Sources/DeckUI/Views/PresenterNotesView.swift
@@ -1,0 +1,36 @@
+//
+//  PresenterView.swift
+//  Demo
+//
+//  Created by Zachary Brass on 1/17/23.
+//
+
+import SwiftUI
+public struct PresenterNotesView: View {
+    @ObservedObject private var presentationState = PresentationState.shared
+    
+    public var body: some View {
+        Text(presentationState.deck.slides()[presentationState.slideIndex].comment ?? "No notes")
+        .frame(minWidth: 100, maxWidth: .infinity, minHeight: 100, maxHeight: .infinity)
+    }
+    public init() {
+    }
+        
+    
+}
+#if canImport(AppKit)
+@available(macOS 13.0, *)
+public struct PresenterNotes: Scene {
+    public var body: some Scene {
+        Window("Presenter Notes", id: "notes") {
+            PresenterNotesView()
+                .toolbar {
+                    SlideNavigationToolbarButtons()
+                }
+        }.keyboardShortcut("1")
+
+    }
+    public init() {
+    }
+}
+#endif

--- a/Sources/DeckUI/Views/SlideNavigation.swift
+++ b/Sources/DeckUI/Views/SlideNavigation.swift
@@ -1,0 +1,45 @@
+//
+//  SlideNavigation.swift
+//  
+//
+//  Created by Zachary Brass on 3/18/23.
+//
+
+import SwiftUI
+
+public struct SlideNavigationToolbarButtons: View {
+    public var body: some View {
+        Group {
+            Button {
+                withAnimation {
+                    PresentationState.shared.previousSlide()
+                }
+            } label: {
+                Label("Previous", systemImage: "arrow.left")
+            }.keyboardShortcut(.leftArrow, modifiers: [])
+            
+            Button {
+                withAnimation {
+                    PresentationState.shared.nextSlide()
+                }
+            } label: {
+                Label("Next", systemImage: "arrow.right")
+            }.keyboardShortcut(.rightArrow, modifiers: [])
+            
+            Button {
+                NotificationCenter.default.post(name: .keyDown, object: nil)
+            } label: {
+                Label("Down", systemImage: "arrow.down")
+            }.keyboardShortcut(.downArrow, modifiers: [])
+            
+            Button {
+                NotificationCenter.default.post(name: .keyUp, object: nil)
+            } label: {
+                Label("Up", systemImage: "arrow.up")
+            }.keyboardShortcut(.upArrow, modifiers: [])
+        }
+    }
+    public init() {
+        
+    }
+}


### PR DESCRIPTION
Refactored the deck state to an ObservableObject singleton so it can be used to update multiple windows and doesn't have to be passed around everywhere.

Presenter notes for each slide can be added to the comments argument in the init method of a Slide.

Arrow keystrokes to change the slide or highlighted line work in both the presenter view and the presenter notes view

#26 