### PR TITLE
Render PDFs

### DIFF
--- a/Sources/DeckUI/DSL/Deck+Rendering.swift
+++ b/Sources/DeckUI/DSL/Deck+Rendering.swift
@@ -1,0 +1,40 @@
+//
+//  Deck+Rendering.swift
+//  
+//
+//  Created by Morten Bek Ditlevsen on 26/03/2023.
+//
+
+import Foundation
+import SwiftUI
+
+extension Deck {
+    @MainActor
+    @available(macOS 13.0, *)
+    public func render(size: CGSize,
+                       url: URL = .documentsDirectory.appending(path: "output.pdf")) -> URL {
+
+        var box = CGRect(origin: .zero, size: size)
+
+        guard let pdf = CGContext(url as CFURL, mediaBox: &box, nil) else {
+            return url
+        }
+
+        for slide in self.slides() {
+            let renderer = ImageRenderer(content:
+                slide.buildView(theme: self.theme)
+                .frame(width: size.width,
+                       height: size.height)
+                    .preferredColorScheme(.dark)
+                    .colorScheme(.dark)
+            )
+            renderer.render { size, context in
+                pdf.beginPDFPage(nil)
+                context(pdf)
+                pdf.endPDFPage()
+            }
+        }
+        pdf.closePDF()
+        return url
+    }
+}


### PR DESCRIPTION
Related to issue #9 

I'm not certain where this API ought to go, but with this PR it's on the `Deck`. If it were on the `Presenter` it could use the default resolution as default rendering size, but it feels a bit weird to have this method on a SwiftUI View...

Let me know what you think - I'll be happy to refactor or redo entirely.