### PR TITLE
Allow configuration of Presenter to fill the screen 

### DIFF
--- a/Sources/DeckUI/Views/Presenter.swift
+++ b/Sources/DeckUI/Views/Presenter.swift
@@ -15,19 +15,21 @@ public struct Presenter: View {
     let loop: Bool
     let defaultResolution: DefaultResolution
     let showCamera: Bool
+    let fillScreen: Bool
     let cameraConfig: CameraConfig
     
     @State var index = 0
     @State var isFullScreen = false
     @State var activeTransition: AnyTransition = .slideFromTrailing
     
-    public init(deck: Deck, slideTransition: SlideTransition? = .horizontal, loop: Bool = false, defaultResolution: DefaultResolution = (width: 1920, height: 1080), showCamera: Bool = false, cameraConfig: CameraConfig = CameraConfig()) {
+    public init(deck: Deck, slideTransition: SlideTransition? = .horizontal, loop: Bool = false, defaultResolution: DefaultResolution = (width: 1920, height: 1080), showCamera: Bool = false, cameraConfig: CameraConfig = CameraConfig(), fillScreen: Bool = false) {
         self.deck = deck
         self.slideTransition = slideTransition
         self.loop = loop
         self.defaultResolution = defaultResolution
         self.showCamera = showCamera
         self.cameraConfig = cameraConfig
+        self.fillScreen = fillScreen
     }
     
     var slide: Slide? {
@@ -36,6 +38,18 @@ public struct Presenter: View {
             return slides[index]
         } else {
             return nil
+        }
+    }
+
+    func frameSize(_ width: Double, _ height: Double) -> CGSize {
+        if fillScreen {
+            let scaleAmount = scaleAmount(width, height)
+            return CGSize(
+                width: max(defaultResolution.width, width / scaleAmount),
+                height: max(defaultResolution.height, height / scaleAmount)
+            )
+        } else {
+            return CGSize(width: defaultResolution.width, height: defaultResolution.height)
         }
     }
     
@@ -55,12 +69,16 @@ public struct Presenter: View {
     
     public var body: some View {
         GeometryReader { proxy in
+            let size = frameSize(proxy.size.width, proxy.size.height)
             ZStack(alignment: .center) {
                 (slide?.theme ?? deck.theme).background
                 
                 self.bodyContents
                     .clipped()
-                    .frame(width: self.defaultResolution.0, height: self.defaultResolution.1, alignment: .center)
+                    .frame(
+                        width: size.width,
+                        height: size.height,
+                        alignment: .center)
                     .scaleEffect(self.scaleAmount(proxy.size.width, proxy.size.height), anchor: .center)
 
                 if self.showCamera {


### PR DESCRIPTION
Allow configuration of Presenter to fill the screen even though the proportions of the actual screen do not align with the defaultResolution.

Currently, if you want edge-to-edge slides, you need to set the defaultResolution to something that has the same proportions as the device you are presenting from.

Maybe you don't always know these proportions, but you would still like the slides to go from edge-to-edge, so that transitions animate all the way to the edges and content takes up as much space as possible.

For an iPad presentation I set the defaultResolution to the exact dimensions of the iPad, but then the font sizes were a bit different from the 'expected' ones in the default theme. When I then started changing font sizes, I then figured that the line spacing between `Words` didn't match the font size.

This PR adds an option to the `Presenter` to do just that. This means that the `defaultResolution` becomes more of a guide for the size of fonts, the spacing and rest of the theme. And since the default values for `defaultResolution` already looks good, then there's much less customization needed by just accepting this option than trying to fiddle with the default resolution and font size.

Let me know if you agree with this - or you have other observations about the best way to produce nice, edge-to-edge slides with balanced fonts on a device you may not know beforehand. :-) 