### PR TITLE
Make Theme extensible

### DIFF
--- a/Sources/DeckUI/DSL/Theme/Theme.swift
+++ b/Sources/DeckUI/DSL/Theme/Theme.swift
@@ -8,13 +8,12 @@
 import SwiftUI
 
 public struct Theme {
-    var background: Color
-    var title: Foreground
-    var subtitle: Foreground
-    var body: Foreground
     
-    public var code: CodeTheme
-    public var codeHighlighted: CodeTheme
+    var values: [ObjectIdentifier: Any] = [:]
+    
+    public init() {
+        self = Theme.black
+    }
     
     public init(background: Color, title: Foreground, subtitle: Foreground, body: Foreground, code: Foreground, codeHighlighted: (Color, Foreground)) {
         self.background = background
@@ -41,6 +40,49 @@ public struct Theme {
         self.body = body
         self.code = code
         self.codeHighlighted = codeHighlighted
+    }
+    
+    public subscript<Key: ThemeKey>(key: Key.Type) -> Key.Value {
+        get {
+            if let value = values[ObjectIdentifier(key)] as? Key.Value {
+                return value
+            } else {
+                return Key.defaultValue
+            }
+        }
+        set {
+            values[ObjectIdentifier(key)] = newValue
+        }
+    }
+    
+    public var background: Color {
+        get { self[BackgroundColorKey.self] }
+        set { self[BackgroundColorKey.self] = newValue }
+    }
+    
+    public var title: Foreground {
+        get { self[TitleKey.self] }
+        set { self[TitleKey.self] = newValue }
+    }
+    
+    public var subtitle: Foreground {
+        get { self[SubtitleKey.self] }
+        set { self[SubtitleKey.self] = newValue }
+    }
+    
+    public var body: Foreground {
+        get { self[BodyKey.self] }
+        set { self[BodyKey.self] = newValue }
+    }
+    
+    public var code: CodeTheme {
+        get { self[CodeKey.self] }
+        set { self[CodeKey.self] = newValue }
+    }
+    
+    public var codeHighlighted: CodeTheme {
+        get { self[HighlightedCodeKey.self] }
+        set { self[HighlightedCodeKey.self] = newValue }
     }
 }
 

--- a/Sources/DeckUI/DSL/Theme/ThemeKey.swift
+++ b/Sources/DeckUI/DSL/Theme/ThemeKey.swift
@@ -1,0 +1,51 @@
+//
+//  ThemeKey.swift
+//  
+//
+//  Created by Danny North on 5/2/23.
+//
+
+import Foundation
+import SwiftUI
+
+public protocol ThemeKey {
+    associatedtype Value
+    
+    static var defaultValue: Value { get }
+}
+
+internal struct BackgroundColorKey: ThemeKey {
+    typealias Value = Color
+    static let defaultValue: Color = .black
+}
+
+internal struct TitleKey: ThemeKey {
+    typealias Value = Foreground
+    static let defaultValue: Foreground = .init(color: .white, font: .system(.headline))
+}
+
+internal struct SubtitleKey: ThemeKey {
+    typealias Value = Foreground
+    static let defaultValue: Foreground = .init(color: .white, font: .system(.subheadline))
+}
+
+internal struct BodyKey: ThemeKey {
+    typealias Value = Foreground
+    static let defaultValue: Foreground = .init(color: .white, font: .system(.body))
+}
+
+internal struct CodeKey: ThemeKey {
+    typealias Value = CodeTheme
+    static let defaultValue: CodeTheme = .init(font: .system(.body, design: .monospaced),
+                                               plainTextColor: .white,
+                                               backgroundColor: .black,
+                                               tokenColors: [:])
+}
+
+internal struct HighlightedCodeKey: ThemeKey {
+    typealias Value = CodeTheme
+    static let defaultValue: CodeTheme = .init(font: .system(.body, design: .monospaced),
+                                               plainTextColor: .white,
+                                               backgroundColor: .black,
+                                               tokenColors: [:])
+}


### PR DESCRIPTION
This makes `Theme` extensible, like SwiftUI's Environment. It holds an infinite number of values that are located based on a type. Users can create their own `ThemeKey`-conforming values and extend the `Theme`, which allows them to customize information in their own custom ContentItems.